### PR TITLE
提供简易批量回放的接口; 修复request中的参数有null时无法录制的问题

### DIFF
--- a/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/RecordService.java
+++ b/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/RecordService.java
@@ -3,6 +3,8 @@ package com.alibaba.repeater.console.service;
 import com.alibaba.jvm.sandbox.repeater.plugin.domain.RepeatModel;
 import com.alibaba.jvm.sandbox.repeater.plugin.domain.RepeaterResult;
 
+import java.util.List;
+
 /**
  * {@link RecordService} 存储服务示例
  * <p>
@@ -48,6 +50,17 @@ public interface RecordService {
     RepeaterResult<String> repeat(String appName, String traceId, String repeatId);
 
 
+
+    /**
+     * 批量执行回放
+     *
+     * @param appName  应用名
+     * @return 回放结果
+     */
+    RepeaterResult<List<RepeaterResult>> batchRepeat(String appName);
+
+
+
     /**
      * 查询回放结果
      *
@@ -55,4 +68,12 @@ public interface RecordService {
      * @return 回放结果
      */
     RepeaterResult<RepeatModel> callback(String repeatId);
+
+    /**
+     * 查询回放结果
+     *
+     * @param appName 应用名
+     * @return 回放结果
+     */
+    RepeaterResult<List<RepeatModel>> batchCallback(String appName);
 }

--- a/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceLocalImpl.java
+++ b/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceLocalImpl.java
@@ -139,13 +139,13 @@ public class RecordServiceLocalImpl extends AbstractRecordService implements Rec
     public RepeaterResult<List<RepeatModel>> batchCallback(String appName) {
         List<Record> records = getRecordByAppName(appName);
         // 根据appName获取对应的traceId
-        List<String> traceIds = new ArrayList<>();
+        List<String> traceIds = new ArrayList();
         for(Record record : records){
             traceIds.add(record.getTraceId());
         }
 
         // 根据traceId从执行结果记录中获取对应的执行结果记录
-        List<String> repeatIds = new ArrayList<>();
+        List<String> repeatIds = new ArrayList();
         for(String key : recordRepeatMap.keySet()){
             if( traceIds.contains(recordRepeatMap.get(key))){
                 repeatIds.add(key);
@@ -154,7 +154,7 @@ public class RecordServiceLocalImpl extends AbstractRecordService implements Rec
         
 
         // 根据从基于traceId过滤获取的执行结果记录中获取其repeatId
-        List<RepeatModel> repeatModels = repeatIds.stream().map(key -> repeatModelCache.get(key)).collect(Collectors.toList());
+        List<RepeatModel> repeatModels = new ArrayList();
         for(String repeatId : repeatIds){
             repeatModels.add(repeatModelCache.get(repeatId));
         }
@@ -179,8 +179,13 @@ public class RecordServiceLocalImpl extends AbstractRecordService implements Rec
      */
     private List<Record> getRecordByAppName(String appName){
         // 遍历recordCache的key，把key中包含了appName的对象放到records中
-        List<String> recordKeys = recordCache.keySet().stream().filter(key -> key.contains(appName)).collect(Collectors.toList());
-        List<Record> records = recordKeys.stream().map(key -> recordCache.get(key)).collect(Collectors.toList());
+        List<Record> records = new ArrayList();
+        for(String key: recordCache.keySet()){
+            if(key.contains(appName)){
+                records.add(recordCache.get(key));
+            }
+        }
+
         return records;
 
     }

--- a/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceLocalImpl.java
+++ b/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceLocalImpl.java
@@ -96,6 +96,7 @@ public class RecordServiceLocalImpl extends AbstractRecordService implements Rec
         RepeaterResult<String> pr = repeat(record, repeatId);
         if (pr.isSuccess()) {
             repeatCache.put(pr.getData(), record);
+            recordRepeatMap.put(pr.getData(), record.getTraceId());
         }
         return pr;
     }

--- a/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceLocalImpl.java
+++ b/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceLocalImpl.java
@@ -185,7 +185,6 @@ public class RecordServiceLocalImpl extends AbstractRecordService implements Rec
                 records.add(recordCache.get(key));
             }
         }
-
         return records;
 
     }

--- a/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceLocalImpl.java
+++ b/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceLocalImpl.java
@@ -110,14 +110,14 @@ public class RecordServiceLocalImpl extends AbstractRecordService implements Rec
         }
         List<RepeaterResult<String>> results = new ArrayList<RepeaterResult<String>>();
 
-        records.forEach(record -> {
+        for(Record record: records){
             RepeaterResult<String> pr = repeat(record, null);
             if (pr.isSuccess()) {
                 repeatCache.put(pr.getData(), record);
                 recordRepeatMap.put(pr.getData(), record.getTraceId());
             }
             results.add(pr);
-        });
+        }
 
         return RepeaterResult.builder().success(true).message("operate success").data(results).build();
     }
@@ -139,14 +139,25 @@ public class RecordServiceLocalImpl extends AbstractRecordService implements Rec
     public RepeaterResult<List<RepeatModel>> batchCallback(String appName) {
         List<Record> records = getRecordByAppName(appName);
         // 根据appName获取对应的traceId
-        List<String> traceIds = records.stream().map(record -> record.getTraceId()).collect(Collectors.toList());
+        List<String> traceIds = new ArrayList<>();
+        for(Record record : records){
+            traceIds.add(record.getTraceId());
+        }
 
         // 根据traceId从执行结果记录中获取对应的执行结果记录
-        List<String> repeatIds = recordRepeatMap.keySet().stream().filter(key -> traceIds.contains(recordRepeatMap.get(key))).collect(Collectors.toList());
+        List<String> repeatIds = new ArrayList<>();
+        for(String key : recordRepeatMap.keySet()){
+            if( traceIds.contains(recordRepeatMap.get(key))){
+                repeatIds.add(key);
+            }
+        }
+        
 
         // 根据从基于traceId过滤获取的执行结果记录中获取其repeatId
         List<RepeatModel> repeatModels = repeatIds.stream().map(key -> repeatModelCache.get(key)).collect(Collectors.toList());
-
+        for(String repeatId : repeatIds){
+            repeatModels.add(repeatModelCache.get(repeatId));
+        }
 
         // 当执行中缓存中存在所需要获取的执行结果记录的repeatId时，则认为这次批量录取回放还在执行中
         for(String repeatId:repeatIds){

--- a/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceMysqlImpl.java
+++ b/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceMysqlImpl.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Resource;
+import java.util.List;
 
 /**
  * {@link RecordServiceMysqlImpl} 使用mysql实现存储
@@ -64,7 +65,17 @@ public class RecordServiceMysqlImpl extends AbstractRecordService implements Rec
     }
 
     @Override
+    public RepeaterResult<List<RepeaterResult>> batchRepeat(String appName) {
+        return null;
+    }
+
+    @Override
     public RepeaterResult<RepeatModel> callback(String repeatId) {
+        return null;
+    }
+
+    @Override
+    public RepeaterResult<List<RepeatModel>> batchCallback(String appName) {
         return null;
     }
 }

--- a/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceProxyImpl.java
+++ b/repeater-console/repeater-console-service/src/main/java/com/alibaba/repeater/console/service/impl/RecordServiceProxyImpl.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Resource;
+import java.util.List;
 
 /**
  * {@link RecordServiceProxyImpl} 示例存储服务代理实现
@@ -47,8 +48,18 @@ public class RecordServiceProxyImpl implements RecordService {
     }
 
     @Override
+    public RepeaterResult<List<RepeaterResult>> batchRepeat(String appName) {
+        return select().batchRepeat(appName);
+    }
+
+    @Override
     public RepeaterResult<RepeatModel> callback(String repeatId) {
         return select().callback(repeatId);
+    }
+
+    @Override
+    public RepeaterResult<List<RepeatModel>> batchCallback(String appName) {
+        return select().batchCallback(appName);
     }
 
     private RecordService select() {

--- a/repeater-console/repeater-console-start/src/main/java/com/alibaba/repeater/console/start/controller/RecordFacadeApi.java
+++ b/repeater-console/repeater-console-start/src/main/java/com/alibaba/repeater/console/start/controller/RecordFacadeApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 
 /**
  * {@link RecordFacadeApi} Demo工程；作为repeater录制回放的数据存储
@@ -34,6 +35,11 @@ public class RecordFacadeApi {
         return recordService.repeat(appName, traceId, request.getHeader("RepeatId"));
     }
 
+    @RequestMapping(value = "repeat/batch/{appName}", method = RequestMethod.GET)
+    public RepeaterResult<List<RepeaterResult>> batchRepeat(@PathVariable("appName") String appName) {
+        return recordService.batchRepeat(appName);
+    }
+
     @RequestMapping(value = "record/save", method = RequestMethod.POST)
     public RepeaterResult<String> recordSave(@RequestBody String body) {
         return recordService.saveRecord(body);
@@ -47,6 +53,11 @@ public class RecordFacadeApi {
     @RequestMapping(value = "repeat/callback/{repeatId}", method = RequestMethod.GET)
     public RepeaterResult<RepeatModel> callback(@PathVariable("repeatId") String repeatId) {
         return recordService.callback(repeatId);
+    }
+
+    @RequestMapping(value = "repeat/callback/batch/{appName}", method = RequestMethod.GET)
+    public RepeaterResult<List<RepeatModel>> batchCallback(@PathVariable("appName") String appName) {
+        return recordService.batchCallback(appName);
     }
 
 }

--- a/repeater-plugin-core/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/core/impl/AbstractInvocationProcessor.java
+++ b/repeater-plugin-core/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/core/impl/AbstractInvocationProcessor.java
@@ -111,6 +111,9 @@ public abstract class AbstractInvocationProcessor implements InvocationProcessor
         List<Class<?>> classes = Lists.newArrayList();
         if (event.argumentArray != null && event.argumentArray.length > 0) {
             for (Object object : event.argumentArray) {
+                if(object == null){
+                    continue;
+                }
                 classes.add(object.getClass());
             }
         }


### PR DESCRIPTION
## 简易批量回放
在RecordServiceLocalImpl中实现了批量回放和批量获取回放结果的方法。并在RecordFacadeApi暴露了对应接口。

### 批量回放接口
* 路径：repeat/batch/{appName}
* 可以回放appName为{appName}的所有录制记录

### 批量获取回放结果接口
* 路径：repeat/callback/batch/{appName}
* 可以获取appName为{appName}的所有录制记录的所有回放结果
* 当执行中缓存中存在所需要获取的执行结果记录的repeatId时，则认为这次批量录取回放还在执行中

## 修复request中参数有null时无法录制的问题
问题：进行录制时当传入参数有null，则会导致录制失败，也无法回放
日志：
![image](https://user-images.githubusercontent.com/7394262/63754846-2594fe00-c8e8-11e9-831f-a9fe73c9e2a7.png)

修复方法：在`getMethodSpec`中加入空判断
```
 private String getMethodSpec(BeforeEvent event) {
        List<Class<?>> classes = Lists.newArrayList();
        if (event.argumentArray != null && event.argumentArray.length > 0) {
            for (Object object : event.argumentArray) {
                if(object == null){
                    continue;
                }
                classes.add(object.getClass());
            }
        }
        return getMethodDesc(event.javaMethodName, classes.toArray(new Class[0]));
    }
```