### PR TITLE
手动关闭ResponseBody,防止提示Did you forget to close a response body?

### DIFF
--- a/repeater-plugin-core/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/core/util/HttpUtil.java
+++ b/repeater-plugin-core/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/core/util/HttpUtil.java
@@ -283,8 +283,9 @@ public class HttpUtil {
      * @return body字符串
      */
     private static Resp executeRequest(Request request, int retryTime) {
+        Response response = null;
         try {
-            Response response = client.newCall(request).execute();
+            response = client.newCall(request).execute();
             if (response.isSuccessful()) {
                 return Resp.builder().code(response.code())
                         .body(bodyToString(response.body())).build();
@@ -309,6 +310,8 @@ public class HttpUtil {
             return Resp.builder().code(500)
                     .message("Invoke occurred exception, request=" + request.toString() + ";message=" + e.getMessage())
                     .build();
+        } finally {
+            response.close();
         }
     }
 


### PR DESCRIPTION
**问题描述:**
偶尔WARN提示ConnectionPool] okhttp3.OkHttpClient   : A connection to *** was leaked. Did you forget to close a response body?

**解决**
手动关闭ResponseBody