### PR TITLE
修复spring-boot-dependencies制定了mysql-connector-java 5.1.42，所以dal中pom指定的…

### DIFF
--- a/repeater-console/pom.xml
+++ b/repeater-console/pom.xml
@@ -58,6 +58,11 @@
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>5.1.44</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>

--- a/repeater-console/repeater-console-dal/pom.xml
+++ b/repeater-console/repeater-console-dal/pom.xml
@@ -31,7 +31,6 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.44</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
…5.1.44版本无法生效