### PR TITLE
[ISSUE #80] dubbo录制问题

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -192,4 +192,4 @@ public void doMock(BeforeEvent event, Boolean entrance, InvokeType type) throws 
 - [插件开发手册](/docs/plugin-development.md)
 
 ## 钉钉交流群
-![pic](http://sandbox-ecological.oss-cn-hangzhou.aliyuncs.com/DingTalkGroup.png)
+![pic](http://sandbox-ecological.oss-cn-hangzhou.aliyuncs.com/DingTalkGroup.jpg)

--- a/Readme.md
+++ b/Readme.md
@@ -192,4 +192,4 @@ public void doMock(BeforeEvent event, Boolean entrance, InvokeType type) throws 
 - [插件开发手册](/docs/plugin-development.md)
 
 ## 钉钉交流群
-![pic](http://sandbox-ecological.oss-cn-hangzhou.aliyuncs.com/DingTalkGroup.jpg)
+![pic](http://sandbox-ecological.oss-cn-hangzhou.aliyuncs.com/DingTalkGroup.png)

--- a/Readme.md
+++ b/Readme.md
@@ -192,4 +192,4 @@ public void doMock(BeforeEvent event, Boolean entrance, InvokeType type) throws 
 - [插件开发手册](/docs/plugin-development.md)
 
 ## 钉钉交流群
-![pic](http://sandbox-ecological.oss-cn-hangzhou.aliyuncs.com/DingTalkGroup.png)
+![pic](http://sandbox-ecological.oss-cn-hangzhou.aliyuncs.com/DingTalkGroup.jpeg)

--- a/repeater-plugin-core/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/core/trace/Tracer.java
+++ b/repeater-plugin-core/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/core/trace/Tracer.java
@@ -67,6 +67,14 @@ public class Tracer {
         return Tracer.getContextCarrie().get();
     }
 
+    public static String getExtra(String key) {
+        return getContext() == null ? null : getContext().getExtra(key);
+    }
+
+    public static String putExtra(String key, String value) {
+        return getContext() == null ? null : getContext().putExtra(key, value);
+    }
+
     /**
      * 获取当前上下文的追踪ID，未开启追踪情况下返回空
      *

--- a/repeater-plugins/dubbo-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/dubbo/DubboConsumerEventListener.java
+++ b/repeater-plugins/dubbo-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/dubbo/DubboConsumerEventListener.java
@@ -16,14 +16,14 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * {@link DubboEventListener}
+ * {@link DubboConsumerEventListener}
  * <p>
  *
  * @author zhaoyb1990
  */
-public class DubboEventListener extends DefaultEventListener {
+public class DubboConsumerEventListener extends DefaultEventListener {
 
-    public DubboEventListener(InvokeType invokeType, boolean entrance, InvocationListener listener, InvocationProcessor processor) {
+    public DubboConsumerEventListener(InvokeType invokeType, boolean entrance, InvocationListener listener, InvocationProcessor processor) {
         super(invokeType, entrance, listener, processor);
     }
 

--- a/repeater-plugins/dubbo-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/dubbo/DubboConsumerPlugin.java
+++ b/repeater-plugins/dubbo-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/dubbo/DubboConsumerPlugin.java
@@ -60,6 +60,6 @@ public class DubboConsumerPlugin extends AbstractInvokePluginAdapter {
 
     @Override
     protected EventListener getEventListener(InvocationListener listener) {
-        return new DubboEventListener(getType(), isEntrance(), listener, getInvocationProcessor());
+        return new DubboConsumerEventListener(getType(), isEntrance(), listener, getInvocationProcessor());
     }
 }

--- a/repeater-plugins/dubbo-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/dubbo/DubboProviderEventListener.java
+++ b/repeater-plugins/dubbo-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/dubbo/DubboProviderEventListener.java
@@ -1,0 +1,77 @@
+package com.alibaba.jvm.sandbox.repeater.plugin.dubbo;
+
+import com.alibaba.jvm.sandbox.api.ProcessControlException;
+import com.alibaba.jvm.sandbox.api.event.BeforeEvent;
+import com.alibaba.jvm.sandbox.api.event.Event;
+import com.alibaba.jvm.sandbox.repeater.plugin.Constants;
+import com.alibaba.jvm.sandbox.repeater.plugin.api.InvocationListener;
+import com.alibaba.jvm.sandbox.repeater.plugin.api.InvocationProcessor;
+import com.alibaba.jvm.sandbox.repeater.plugin.core.cache.RepeatCache;
+import com.alibaba.jvm.sandbox.repeater.plugin.core.trace.Tracer;
+import com.alibaba.jvm.sandbox.repeater.plugin.core.util.LogUtil;
+import com.alibaba.jvm.sandbox.repeater.plugin.domain.InvokeType;
+import org.apache.commons.lang3.reflect.MethodUtils;
+
+public class DubboProviderEventListener extends DubboConsumerEventListener {
+
+    private static final String ON_RESPONSE = "onResponse";
+
+    public DubboProviderEventListener(InvokeType invokeType, boolean entrance, InvocationListener listener, InvocationProcessor processor) {
+        super(invokeType, entrance, listener, processor);
+    }
+
+    @Override
+    protected void initContext(Event event) {
+        if (entrance && isEntranceBegin(event)) {
+            Object invocation = ((BeforeEvent) event).argumentArray[1];
+
+            Object traceId = null;
+            try {
+                traceId = MethodUtils.invokeMethod(invocation, "getAttachment", Constants.HEADER_TRACE_ID);
+            } catch (Exception e) {
+                LogUtil.warn("get invocation attachment exception.", e);
+            }
+
+            if (traceId == null) {
+                Tracer.start();
+            } else {
+                Tracer.start(String.valueOf(traceId));
+            }
+        }
+    }
+
+    @Override
+    protected void doBefore(BeforeEvent event) throws ProcessControlException {
+        if (RepeatCache.isRepeatFlow(Tracer.getTraceId())) {
+            return;
+        }
+
+        super.doBefore(event);
+    }
+
+    @Override
+    protected boolean isEntranceBegin(Event event) {
+        if (event.type != Event.Type.BEFORE) {
+            return false;
+        }
+
+        String methodName = ((BeforeEvent) event).javaMethodName;
+        if (ON_RESPONSE.equals(methodName)) {
+            //标记已经调用过ContextFilter$ContextListener.onResponse的BeforeEvent
+            Tracer.putExtra(ON_RESPONSE, ON_RESPONSE);
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    protected boolean isEntranceFinish(Event event) {
+        if (event.type == Event.Type.BEFORE || Tracer.getContext().getInvokeType() != invokeType) {
+            return false;
+        }
+
+        //已经调用过ContextFilter$ContextListener.onResponse的BeforeEvent
+        return Tracer.getExtra(ON_RESPONSE) != null;
+    }
+}

--- a/repeater-plugins/dubbo-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/dubbo/DubboProviderPlugin.java
+++ b/repeater-plugins/dubbo-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/dubbo/DubboProviderPlugin.java
@@ -59,6 +59,6 @@ public class DubboProviderPlugin extends AbstractInvokePluginAdapter {
 
     @Override
     protected EventListener getEventListener(InvocationListener listener) {
-        return new DubboEventListener(getType(), isEntrance(), listener, getInvocationProcessor());
+        return new DubboProviderEventListener(getType(), isEntrance(), listener, getInvocationProcessor());
     }
 }

--- a/repeater-plugins/dubbo-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/dubbo/DubboRepeater.java
+++ b/repeater-plugins/dubbo-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/dubbo/DubboRepeater.java
@@ -1,5 +1,6 @@
 package com.alibaba.jvm.sandbox.repeater.plugin.dubbo;
 
+import com.alibaba.jvm.sandbox.repeater.plugin.Constants;
 import com.alibaba.jvm.sandbox.repeater.plugin.core.impl.AbstractRepeater;
 import com.alibaba.jvm.sandbox.repeater.plugin.domain.DubboInvocation;
 import com.alibaba.jvm.sandbox.repeater.plugin.domain.Invocation;
@@ -12,6 +13,7 @@ import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.context.ConfigManager;
+import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.service.GenericService;
 import org.kohsuke.MetaInfServices;
 
@@ -70,6 +72,7 @@ public class DubboRepeater extends AbstractRepeater {
         ClassLoader swap = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(GenericService.class.getClassLoader());
+            RpcContext.getContext().setAttachment(Constants.HEADER_TRACE_ID, context.getTraceId());
             GenericService genericService = reference.get();
             return genericService.$invoke(dubboInvocation.getMethodName(), dubboInvocation.getParameterTypes(), invocation.getRequest());
         } finally {


### PR DESCRIPTION
先说结论，dubbo流量录制拿不到subInvocations的问题是因为同时注册了invoke和onResponse两个方法，
然后以下方法的调用将invoke时创建的trace context清除了，所以onResponse开启的新trace拿不到subInvocations
https://github.com/alibaba/jvm-sandbox-repeater/blob/eec17d865dc43d163c7b0447884e9ec02a11a4c9/repeater-plugin-core/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/core/impl/api/DefaultEventListener.java#L140

相比于PR https://github.com/alibaba/jvm-sandbox-repeater/pull/79 本PR调整很小，核心逻辑是调整了默认的isEntranceBegin、isEntranceFinish。