### PR TITLE
Bumps fastjson from 1.2.67.sec10 to 1.2.83.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <logback.version>1.2.1</logback.version>
         <ttl.version>2.10.2</ttl.version>
         <guava.version>19.0</guava.version>
-        <fastjson.version>1.2.67.sec10</fastjson.version>
+        <fastjson.version>1.2.83</fastjson.version>
         <commons-io.version>2.5</commons-io.version>
         <commons-lang3.version>3.6</commons-lang3.version>
         <commons-io.version>2.5</commons-io.version>


### PR DESCRIPTION
> Release notes
Sourced from [fastjson's releases](https://github.com/alibaba/fastjson/releases).

> Commits
- 26f13f8 1.2.83
- 8f3410f bug fix for autotype
- cd3c2de improved jdk8 java.time support
- c63866e remove unused import
- 35db4ad bug fix for autoType
- 3f009e1 Merge pull request #4085 from hengyunabc/fix_setAccessible
- dd3de5f fix InaccessibleObjectException in jdk17. #4077
- a234f9a Merge pull request #4084 from alibaba/revert-4078-master
- 0814909 Revert "fix InaccessibleObjectException in jdk17. #4077"
- ab82d0b Merge pull request #4078 from hengyunabc/master
- Additional commits viewable in compare view