### PR TITLE
修复一些问题

### DIFF
--- a/repeater-aide/src/main/java/com/alibaba/jvm/sandbox/repeater/aide/compare/comparator/SimpleComparator.java
+++ b/repeater-aide/src/main/java/com/alibaba/jvm/sandbox/repeater/aide/compare/comparator/SimpleComparator.java
@@ -34,12 +34,12 @@ public class SimpleComparator implements Comparator {
         }
         Class<?> lCs = left.getClass();
         Class<?> rCs = right.getClass();
+        if (isArray(lCs, rCs) || isCollection(lCs, rCs) || isMap(lCs, rCs)) {
+            return false;
+        }
         // type different
         if (lCs != rCs) {
             return true;
-        }
-        if (isArray(lCs, rCs) || isCollection(lCs, rCs) || isMap(lCs, rCs)) {
-            return false;
         }
         // basic type or java.lang or java.math or java.time or java.util
         return isBasicType(lCs, rCs) || isBothJavaLang(lCs, rCs)

--- a/repeater-plugins/okhttp-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/okhttp/OkhttpInvocationProcessor.java
+++ b/repeater-plugins/okhttp-plugin/src/main/java/com/alibaba/jvm/sandbox/repeater/plugin/okhttp/OkhttpInvocationProcessor.java
@@ -159,7 +159,7 @@ public class OkhttpInvocationProcessor extends DefaultInvocationProcessor {
             // 构建返回body体
             Map<String, Object> responseMap = (Map<String, Object>) invocation.getResponse();
             if (MapUtils.isEmpty(responseMap)){
-                new Object();
+                return new Object();
             }
 
             String responseStr = (String)responseMap.get("responseBody");


### PR DESCRIPTION
1、修复OkHttp插件构造mock响应时条件判断缺失的终止关键字
2、修复SimpleComparator的条件判断顺序，这是由于SimpleComparator的优先级较高，当业务代码使用Arrays.asList作为参数时会导致错误的进入SimpleComparator的compare中（ArrayList和Arrays$ArrayList的类型并不相同），并返回type_diff的结果